### PR TITLE
test support for ip v6 address

### DIFF
--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'typhoeus' # used in net_adapter
   spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'ipaddress'
   # webmock 2 not yet compatible out of the box with VCR
   spec.add_development_dependency 'webmock', '< 2' # used in vcr
 end

--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'typhoeus' # used in net_adapter
   spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'ipaddress'
   # webmock 2 not yet compatible out of the box with VCR
   spec.add_development_dependency 'webmock', '< 2' # used in vcr
 end

--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -1,7 +1,7 @@
 require 'geokit/net_adapter/net_http'
 require 'geokit/net_adapter/typhoeus'
 require 'ipaddr'
-require 'ipaddress'
+require 'resolv'
 require 'json'
 require 'logger'
 require 'net/http'

--- a/lib/geokit/geocoders/base_ip.rb
+++ b/lib/geokit/geocoders/base_ip.rb
@@ -27,7 +27,7 @@ module Geokit
       end
 
       def self.ip?(ip)
-        IPAddress.valid?(ip)
+        Resolv::IPv4::Regex.match(ip) || Resolv::IPv6::Regex.match(ip)
       end
 
       def self.process(format, ip)

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -71,7 +71,7 @@ module Geokit
         if args.last.is_a?(Hash) && args.last.key?(:provider_order)
           args.last.delete(:provider_order)
         else
-          if IPAddress.valid?(address)
+          if Resolv::IPv4::Regex.match(ip) || Resolv::IPv6::Regex.match(ip)
             Geokit::Geocoders.ip_provider_order
           else
             Geokit::Geocoders.provider_order

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -71,7 +71,7 @@ module Geokit
         if args.last.is_a?(Hash) && args.last.key?(:provider_order)
           args.last.delete(:provider_order)
         else
-          if Resolv::IPv4::Regex.match(ip) || Resolv::IPv6::Regex.match(ip)
+          if Resolv::IPv4::Regex.match(address) || Resolv::IPv6::Regex.match(address)
             Geokit::Geocoders.ip_provider_order
           else
             Geokit::Geocoders.provider_order

--- a/test/test_ipgeocoder.rb
+++ b/test/test_ipgeocoder.rb
@@ -64,6 +64,22 @@ class IpGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert location.success?
   end
 
+  def test_ip_v6_address
+    success = MockSuccess.new
+    success.expects(:body).returns(IP_SUCCESS)
+    url = "#{@base_url}?ip=3bfa:e8a1:79da:4e93:a383:6ac8:db47:c705&position=true"
+    Geokit::Geocoders::IpGeocoder.expects(:call_geocoder_service).with(url).returns(success)
+    location = Geokit::Geocoders::IpGeocoder.geocode('3bfa:e8a1:79da:4e93:a383:6ac8:db47:c705')
+    assert_not_nil location
+    assert_equal 41.7696, location.lat
+    assert_equal(-88.4588, location.lng)
+    assert_equal 'Sugar Grove', location.city
+    assert_equal 'IL', location.state
+    assert_equal 'US', location.country_code
+    assert_equal 'ip', location.provider
+    assert location.success?
+  end
+
   def test_unicoded_lookup
     success = MockSuccess.new
     success.expects(:body).returns(IP_UNICODED)


### PR DESCRIPTION
ticket: [DEV-1491](https://app.clickup.com/t/1pkjh4b)
@v-ruiz tu avais rajouté un "require "ipaddress"" mais cette gem n'est dispo que dans le bundle de epicery.
J'ai rajouté la dépendance au projet geokit et rajouter un test.
Quand c'est mergé, il faudra aller vérifier que la PR chez Geokit contient bien le test maintenant https://github.com/geokit/geokit/pull/255